### PR TITLE
feat(output): pretty print marble differences for value objects

### DIFF
--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -11,6 +11,14 @@ describe('toBeObservable matcher test', () => {
         expect(a$.pipe(concat(b$))).toBeObservable(expected);
     });
 
+    it('Should work for value objects', () => {
+        const valueObject = {foo: 'bar'};
+        const a$ = cold('-a-|', {a: valueObject});
+        const expected = cold('-a-|', {a: valueObject});
+
+        expect(a$).toBeObservable(expected);
+    });
+
     it('Should merge two hot observables and start emitting from the subscription point', () => {
         const e1 = hot('----a--^--b-------c--|', );
         const e2 = hot(  '---d-^--e---------f-----|', );

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -1,6 +1,5 @@
 import { Marblizer } from '../marblizer';
 import diff from 'jest-diff';
-import equal from 'fast-deep-equal';
 import { printExpected, printReceived, matcherHint } from 'jest-matcher-utils';
 import { TestMessage } from 'rxjs/testing/TestMessage';
 import { SubscriptionLog } from 'rxjs/testing/SubscriptionLog';
@@ -14,18 +13,19 @@ function haveValueObjects(actual: TestMessage[], expected: TestMessage[]) {
 
 export const customTestMatchers = {
   toBeNotifications(actual: TestMessage[], expected: TestMessage[]) {
-    let actualMarble: string | TestMessage[];
-    let expectedMarble: string | TestMessage[];
+    let actualMarble: string;
+    let expectedMarble: string;
 
     if (haveValueObjects(actual, expected)) {
-      actualMarble = actual;
-      expectedMarble = expected;
+      const spaces = 2;
+      actualMarble = JSON.stringify(actual, null, spaces);
+      expectedMarble = JSON.stringify(expected, null, spaces);
     } else {
       actualMarble = Marblizer.marblize(actual);
       expectedMarble = Marblizer.marblize(expected);
     }
 
-    const pass = equal(actualMarble, expectedMarble);
+    const pass = actualMarble === expectedMarble;
 
     const message = pass
       ? () =>

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -1,5 +1,6 @@
 import { Marblizer } from '../marblizer';
 import diff from 'jest-diff';
+import equal from 'fast-deep-equal';
 import { printExpected, printReceived, matcherHint } from 'jest-matcher-utils';
 import { TestMessage } from 'rxjs/testing/TestMessage';
 import { SubscriptionLog } from 'rxjs/testing/SubscriptionLog';
@@ -13,18 +14,18 @@ function haveValueObjects(actual: TestMessage[], expected: TestMessage[]) {
 
 export const customTestMatchers = {
   toBeNotifications(actual: TestMessage[], expected: TestMessage[]) {
-    let actualMarble: string;
-    let expectedMarble: string;
+    let actualMarble: string | TestMessage[];
+    let expectedMarble: string | TestMessage[];
 
     if (haveValueObjects(actual, expected)) {
-      actualMarble = JSON.stringify(actual);
-      expectedMarble = JSON.stringify(expected);
+      actualMarble = actual;
+      expectedMarble = expected;
     } else {
       actualMarble = Marblizer.marblize(actual);
       expectedMarble = Marblizer.marblize(expected);
     }
 
-    const pass = actualMarble === expectedMarble;
+    const pass = equal(actualMarble, expectedMarble);
 
     const message = pass
       ? () =>


### PR DESCRIPTION
Thanks for the work on jest-marbles!

I thought I'd try and make the test failure output a little easier to read. This uses [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal), which seems to be an existing dependency from jest.

![screen shot 2018-05-31 at 4 09 22 pm](https://user-images.githubusercontent.com/1791439/40782135-c1e2f324-6521-11e8-8c46-be9789676a11.png)
