### PR TITLE
feat(output): pretty print marble differences for value objects

### DIFF
--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -11,6 +11,14 @@ describe('toBeObservable matcher test', () => {
         expect(a$.pipe(concat(b$))).toBeObservable(expected);
     });
 
+    it('Should work for value objects', () => {
+        const valueObject = {foo: 'bar'};
+        const a$ = cold('-a-|', {a: valueObject});
+        const expected = cold('-a-|', {a: valueObject});
+
+        expect(a$).toBeObservable(expected);
+    });
+
     it('Should merge two hot observables and start emitting from the subscription point', () => {
         const e1 = hot('----a--^--b-------c--|', );
         const e2 = hot(  '---d-^--e---------f-----|', );


### PR DESCRIPTION
This is the other approach I mentioned in https://github.com/meltedspark/jest-marbles/pull/26, which still gives the same prettified output.

![image](https://user-images.githubusercontent.com/1791439/40782810-d90e8c50-6523-11e8-8c7e-cfd2a2d12e61.png)
