### PR TITLE
Fixes notification events that evaluate to multi character strings.

### DIFF
--- a/spec/marblizer.spec.ts
+++ b/spec/marblizer.spec.ts
@@ -30,6 +30,17 @@ describe('Marblizer test', () => {
     expect(marble).toEqual('---(be)----#');
   });
 
+  fit('should marblize TestMessages with multi-character literals', () => {
+    const sample: TestMessage[] = [
+      { frame: 20, notification: new Notification('N', true) },
+      { frame: 40, notification: new Notification('N', false) },
+      { frame: 60, notification: new Notification('N', null) },
+      { frame: 80, notification: new Notification('C') }
+    ];
+    const marble = Marblizer.marblize(sample);
+    expect(marble).toEqual('--(true)--(false)--(null)--|');
+  });
+
   it('Should marblize TestMessages without completion', () => {
     const sample: TestMessage[] = [
       {frame: 30, notification: new Notification('N', 'b')},

--- a/spec/marblizer.spec.ts
+++ b/spec/marblizer.spec.ts
@@ -30,17 +30,6 @@ describe('Marblizer test', () => {
     expect(marble).toEqual('---(be)----#');
   });
 
-  fit('should marblize TestMessages with multi-character literals', () => {
-    const sample: TestMessage[] = [
-      { frame: 20, notification: new Notification('N', true) },
-      { frame: 40, notification: new Notification('N', false) },
-      { frame: 60, notification: new Notification('N', null) },
-      { frame: 80, notification: new Notification('C') }
-    ];
-    const marble = Marblizer.marblize(sample);
-    expect(marble).toEqual('--(true)--(false)--(null)--|');
-  });
-
   it('Should marblize TestMessages without completion', () => {
     const sample: TestMessage[] = [
       { frame: 30, notification: new Notification('N', 'b') },

--- a/spec/marblizer.spec.ts
+++ b/spec/marblizer.spec.ts
@@ -1,18 +1,18 @@
-import {Marblizer} from '../src/marblizer';
-import {TestMessage} from 'rxjs/internal/testing/TestMessage';
-import {Notification} from 'rxjs';
-import {SubscriptionLog} from 'rxjs/internal/testing/SubscriptionLog';
+import { Notification } from 'rxjs';
+import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
+import { TestMessage } from 'rxjs/internal/testing/TestMessage';
+import { Marblizer } from '../src/marblizer';
 
 describe('Marblizer test', () => {
   it('Should marblize TestMessages', () => {
     // First dash is frame 0
     // ---(be)----c-f-----|
     const sample: TestMessage[] = [
-      {frame: 30, notification: new Notification('N', 'b')},
-      {frame: 30, notification: new Notification('N', 'e')},
-      {frame: 110, notification: new Notification('N', 'c')},
-      {frame: 130, notification: new Notification('N', 'f')},
-      {frame: 190, notification: new Notification('C')}
+      { frame: 30, notification: new Notification('N', 'b') },
+      { frame: 30, notification: new Notification('N', 'e') },
+      { frame: 110, notification: new Notification('N', 'c') },
+      { frame: 130, notification: new Notification('N', 'f') },
+      { frame: 190, notification: new Notification('C') }
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -21,9 +21,9 @@ describe('Marblizer test', () => {
 
   it('Should marblize TestMessages with error', () => {
     const sample: TestMessage[] = [
-      {frame: 30, notification: new Notification('N', 'b')},
-      {frame: 30, notification: new Notification('N', 'e')},
-      {frame: 110, notification: new Notification('E')}
+      { frame: 30, notification: new Notification('N', 'b') },
+      { frame: 30, notification: new Notification('N', 'e') },
+      { frame: 110, notification: new Notification('E') }
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -43,8 +43,8 @@ describe('Marblizer test', () => {
 
   it('Should marblize TestMessages without completion', () => {
     const sample: TestMessage[] = [
-      {frame: 30, notification: new Notification('N', 'b')},
-      {frame: 110, notification: new Notification('N', 'e')}
+      { frame: 30, notification: new Notification('N', 'b') },
+      { frame: 110, notification: new Notification('N', 'e') }
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -53,7 +53,7 @@ describe('Marblizer test', () => {
 
   it('Should marblize TestMessages without emission (but with completion)', () => {
     const sample: TestMessage[] = [
-      {frame: 110, notification: new Notification('C')}
+      { frame: 110, notification: new Notification('C') }
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -62,8 +62,8 @@ describe('Marblizer test', () => {
 
   it('Should throw exception if there was any unsupported notification kind', () => {
     const sample: TestMessage[] = [
-      {frame: 30, notification: new Notification('N', 'b')},
-      {frame: 110, notification: new Notification('A', 'e')}
+      { frame: 30, notification: new Notification('N', 'b') },
+      { frame: 110, notification: new Notification('A', 'e') }
     ];
     expect(() => Marblizer.marblize(sample)).toThrow('Unsupported notification kind');
   });

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -1,38 +1,47 @@
-import {cold, hot, Scheduler, time} from '../index';
-import {concat, merge, mapTo} from 'rxjs/operators';
-import {timer} from 'rxjs';
+import { merge, timer } from 'rxjs';
+import { concat, mapTo } from 'rxjs/operators';
+import { cold, hot, Scheduler, time } from '../index';
 
 describe('toBeObservable matcher test', () => {
-    it('Should concatenate two cold observables into single cold observable', () => {
+  it('Should concatenate two cold observables into single cold observable', () => {
         const a$ = cold('-a-|', {a: 0});
         const b$ = cold('-b-|', {b: 1});
         const expected = cold('-a--b-|', {a: 0, b:1});
 
-        expect(a$.pipe(concat(b$))).toBeObservable(expected);
-    });
+    expect(a$.pipe(concat(b$))).toBeObservable(expected);
+  });
 
-    it('Should work for value objects', () => {
+  it('Should work for value objects', () => {
         const valueObject = {foo: 'bar'};
         const a$ = cold('-a-|', {a: valueObject});
         const expected = cold('-a-|', {a: valueObject});
 
-        expect(a$).toBeObservable(expected);
-    });
+    expect(a$).toBeObservable(expected);
+  });
 
-    it('Should merge two hot observables and start emitting from the subscription point', () => {
+  it('should work for multi-character literals', () => {
+    const falses$ = cold('--a-----b-----|');
+    const trues$ = cold('-----a-----b--|');
+    const expected = cold('--f--t--f--t--|', { t: true, f: false });
+    const mapped = merge(falses$.pipe(mapTo(false)), trues$.pipe(mapTo(true)));
+
+    expect(mapped).toBeObservable(expected);
+  });
+
+  it('Should merge two hot observables and start emitting from the subscription point', () => {
         const e1 = hot('----a--^--b-------c--|', );
         const e2 = hot(  '---d-^--e---------f-----|', );
         const expected = cold('---(be)----c-f-----|', );
 
-        expect(e1.pipe(merge(e2))).toBeObservable(expected);
-    });
+    expect(merge(e1, e2)).toBeObservable(expected);
+  });
 
-    it('Should delay the emission by provided timeout with provided scheduler', () => {
-        const delay = time('-----d|');
-        const provided = timer(delay, Scheduler.get()).pipe(mapTo(0));
+  it('Should delay the emission by provided timeout with provided scheduler', () => {
+    const delay = time('-----d|');
+    const provided = timer(delay, Scheduler.get()).pipe(mapTo(0));
         const expected = hot('------(d|)', {d: 0});
 
-        expect(provided).toBeObservable(expected);
-    });
+    expect(provided).toBeObservable(expected);
+  });
 
 });

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -27,6 +27,16 @@ describe('toBeObservable matcher test', () => {
 
     expect(mapped).toBeObservable(expected);
   });
+  
+  it('should work for mixed literals', () => {
+    const falses$ = cold('--a-----a-----|', {a: false});
+    const trues$ = cold('-----b-----b--|', {b: true});
+	const characters$ = cold('-------------c-|')
+    const expected = cold('--f--t--f--t--c-|', { t: true, f: false });
+    const mapped = merge(falses$, trues$, characters$);
+
+    expect(mapped).toBeObservable(expected);
+  });
 
   it('Should merge two hot observables and start emitting from the subscription point', () => {
     const e1 = hot('----a--^--b-------c--|');

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -32,7 +32,7 @@ describe('toBeObservable matcher test', () => {
     const falses$ = cold('--a-----a-----|', {a: false});
     const trues$ = cold('-----b-----b--|', {b: true});
 	const characters$ = cold('-------------c-|')
-    const expected = cold('--f--t--f--t--c-|', { t: true, f: false });
+    const expected = cold('--f--t--f--t-c-|', { t: true, f: false, c: 'c' });
     const mapped = merge(falses$, trues$, characters$);
 
     expect(mapped).toBeObservable(expected);

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -4,17 +4,17 @@ import { cold, hot, Scheduler, time } from '../index';
 
 describe('toBeObservable matcher test', () => {
   it('Should concatenate two cold observables into single cold observable', () => {
-        const a$ = cold('-a-|', {a: 0});
-        const b$ = cold('-b-|', {b: 1});
-        const expected = cold('-a--b-|', {a: 0, b:1});
+    const a$ = cold('-a-|', { a: 0 });
+    const b$ = cold('-b-|', { b: 1 });
+    const expected = cold('-a--b-|', { a: 0, b: 1 });
 
     expect(a$.pipe(concat(b$))).toBeObservable(expected);
   });
 
   it('Should work for value objects', () => {
-        const valueObject = {foo: 'bar'};
-        const a$ = cold('-a-|', {a: valueObject});
-        const expected = cold('-a-|', {a: valueObject});
+    const valueObject = { foo: 'bar' };
+    const a$ = cold('-a-|', { a: valueObject });
+    const expected = cold('-a-|', { a: valueObject });
 
     expect(a$).toBeObservable(expected);
   });
@@ -29,9 +29,9 @@ describe('toBeObservable matcher test', () => {
   });
 
   it('Should merge two hot observables and start emitting from the subscription point', () => {
-        const e1 = hot('----a--^--b-------c--|', );
-        const e2 = hot(  '---d-^--e---------f-----|', );
-        const expected = cold('---(be)----c-f-----|', );
+    const e1 = hot('----a--^--b-------c--|');
+    const e2 = hot('---d-^--e---------f-----|');
+    const expected = cold('---(be)----c-f-----|');
 
     expect(merge(e1, e2)).toBeObservable(expected);
   });
@@ -39,7 +39,7 @@ describe('toBeObservable matcher test', () => {
   it('Should delay the emission by provided timeout with provided scheduler', () => {
     const delay = time('-----d|');
     const provided = timer(delay, Scheduler.get()).pipe(mapTo(0));
-        const expected = hot('------(d|)', {d: 0});
+    const expected = hot('------(d|)', { d: 0 });
 
     expect(provided).toBeObservable(expected);
   });

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -4,11 +4,11 @@ import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { Marblizer } from '../marblizer';
 
-function shouldMarblize(...messages: TestMessage[][]) {
-  return messages.map(message => message.some(m => marblizeCheck(m))).includes(true);
+function containNonCharacterValue(...messages: TestMessage[][]) {
+  return messages.map(message => message.some(m => !isCharacter(m))).includes(true);
 }
 
-function marblizeCheck(m: TestMessage): boolean {
+function isCharacter(m: TestMessage): boolean {
   return typeof m.notification.value === 'string' && m.notification.value.length === 1;
 }
 
@@ -17,7 +17,7 @@ export const customTestMatchers = {
     let actualMarble: string;
     let expectedMarble: string;
 
-    if (shouldMarblize(actual, expected)) {
+    if (!containNonCharacterValue(actual, expected)) {
       actualMarble = Marblizer.marblize(actual);
       expectedMarble = Marblizer.marblize(expected);
     } else {

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -1,4 +1,4 @@
-import diff from 'jest-diff';
+import * as diff from 'jest-diff';
 import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 import { TestMessage } from 'rxjs/internal/testing/TestMessage';

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -5,7 +5,7 @@ import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { Marblizer } from '../marblizer';
 
 function containNonCharacterValue(...messages: TestMessage[][]) {
-  return messages.map(message => message.some(m => !isCharacter(m))).includes(true);
+  return messages.some(message => message.some(m => !isCharacter(m)));
 }
 
 function isCharacter(m: TestMessage): boolean {

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -1,14 +1,22 @@
-import { Marblizer } from '../marblizer';
 import diff from 'jest-diff';
-import { printExpected, printReceived, matcherHint } from 'jest-matcher-utils';
-import { TestMessage } from 'rxjs/internal/testing/TestMessage';
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
+import { TestMessage } from 'rxjs/internal/testing/TestMessage';
+import { Marblizer } from '../marblizer';
 
 function haveValueObjects(actual: TestMessage[], expected: TestMessage[]) {
   return (
-    actual.some(m => m.notification.value instanceof Object) ||
-    expected.some(m => m.notification.value instanceof Object)
+    actual.some(m => isObject(m.notification.value) || isLiteral(m.notification.value)) ||
+    expected.some(m => isObject(m.notification.value) || isLiteral(m.notification.value))
   );
+}
+
+function isObject(maybeObject: any) {
+  return maybeObject instanceof Object;
+}
+
+function isLiteral(maybeLiteral: any) {
+  return ['boolean', 'undefined'].some(type => typeof maybeLiteral === type);
 }
 
 export const customTestMatchers = {

--- a/src/jest/custom-matchers.ts
+++ b/src/jest/custom-matchers.ts
@@ -4,19 +4,12 @@ import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { Marblizer } from '../marblizer';
 
-function haveValueObjects(actual: TestMessage[], expected: TestMessage[]) {
-  return (
-    actual.some(m => isObject(m.notification.value) || isLiteral(m.notification.value)) ||
-    expected.some(m => isObject(m.notification.value) || isLiteral(m.notification.value))
-  );
+function shouldMarblize(...messages: TestMessage[][]) {
+  return messages.map(message => message.some(m => marblizeCheck(m))).includes(true);
 }
 
-function isObject(maybeObject: any) {
-  return maybeObject instanceof Object;
-}
-
-function isLiteral(maybeLiteral: any) {
-  return ['boolean', 'undefined'].some(type => typeof maybeLiteral === type);
+function marblizeCheck(m: TestMessage): boolean {
+  return typeof m.notification.value === 'string' && m.notification.value.length === 1;
 }
 
 export const customTestMatchers = {
@@ -24,13 +17,13 @@ export const customTestMatchers = {
     let actualMarble: string;
     let expectedMarble: string;
 
-    if (haveValueObjects(actual, expected)) {
+    if (shouldMarblize(actual, expected)) {
+      actualMarble = Marblizer.marblize(actual);
+      expectedMarble = Marblizer.marblize(expected);
+    } else {
       const spaces = 2;
       actualMarble = JSON.stringify(actual, null, spaces);
       expectedMarble = JSON.stringify(expected, null, spaces);
-    } else {
-      actualMarble = Marblizer.marblize(actual);
-      expectedMarble = Marblizer.marblize(expected);
     }
 
     const pass = actualMarble === expectedMarble;

--- a/src/marblizer.ts
+++ b/src/marblizer.ts
@@ -10,8 +10,8 @@ export class Marblizer {
   public static marblize(messages: TestMessage[]): string {
     const emissions = Marblizer.getNotificationEvents(messages);
     let marbles = '';
-    for (let i = 0; i < emissions.length; i++) {
-      marbles = `${marbles}${MarblesGlossary.TimeFrame.repeat(emissions[i].diff(emissions[i - 1])) +
+    for (let i = 0, prevEndFrame = 0; i < emissions.length; prevEndFrame = emissions[i].end, i++) {
+      marbles = `${marbles}${MarblesGlossary.TimeFrame.repeat(emissions[i].start - prevEndFrame) +
         emissions[i].marbles}`;
     }
     return marbles;

--- a/src/marblizer.ts
+++ b/src/marblizer.ts
@@ -1,8 +1,8 @@
-import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
+import { TestMessage } from 'rxjs/internal/testing/TestMessage';
 import { MarblesGlossary } from './marbles-glossary';
-import { NotificationKindChars, ValueLiteral } from './notification-kind';
 import { NotificationEvent } from './notification-event';
+import { NotificationKindChars, ValueLiteral } from './notification-kind';
 
 const frameStep = 10;
 
@@ -10,8 +10,8 @@ export class Marblizer {
   public static marblize(messages: TestMessage[]): string {
     const emissions = Marblizer.getNotificationEvents(messages);
     let marbles = '';
-    for (let i = 0, prevEndFrame = 0; i < emissions.length; prevEndFrame = emissions[i].end, i++) {
-      marbles = `${marbles}${MarblesGlossary.TimeFrame.repeat(emissions[i].start - prevEndFrame) +
+    for (let i = 0; i < emissions.length; i++) {
+      marbles = `${marbles}${MarblesGlossary.TimeFrame.repeat(emissions[i].diff(emissions[i - 1])) +
         emissions[i].marbles}`;
     }
     return marbles;

--- a/src/notification-event.ts
+++ b/src/notification-event.ts
@@ -4,17 +4,4 @@ export class NotificationEvent {
   get end(): number {
     return this.start + this.marbles.length;
   }
-
-  /**
-   * Returns the difference (in empty time frames) between a NotificationEvent
-   * and the previous NotificationEvent.
-   *
-   * @param prev previous event.
-   */
-  diff(prev?: NotificationEvent) {
-    if (prev) {
-      return this.start - prev.start;
-    }
-    return this.start;
-  }
 }

--- a/src/notification-event.ts
+++ b/src/notification-event.ts
@@ -4,4 +4,17 @@ export class NotificationEvent {
   get end(): number {
     return this.start + this.marbles.length;
   }
+
+  /**
+   * Returns the difference (in empty time frames) between a NotificationEvent
+   * and the previous NotificationEvent.
+   *
+   * @param prev previous event.
+   */
+  diff(prev?: NotificationEvent) {
+    if (prev) {
+      return this.start - prev.start;
+    }
+    return this.start;
+  }
 }


### PR DESCRIPTION
Fixes #75 .

This should do the trick. I ran prettier and tslint on my commit which sort of mangled some spacing and imports. I can revert those chunks but then Husky won't allow me to commit.