### PR TITLE
feat: support aligning marble strings using leading spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Verifies that the resulting stream emits certain values at certain time frames
 ```js
     it('Should merge two hot observables and start emitting from the subscription point', () => {
         const e1 = hot('----a--^--b-------c--|', {a: 0});
-        const e2 = hot(  '---d-^--e---------f-----|', {a: 0});
+        const e2 = hot('  ---d-^--e---------f-----|', {a: 0});
         const expected = cold('---(be)----c-f-----|', {a: 0});
 
         expect(e1.pipe(merge(e2))).toBeObservable(expected);
@@ -80,11 +80,11 @@ Verifies that the observable was subscribed in the provided time frames.
 Useful, for example, when you want to verify that particular `switchMap` worked as expected:
 ```js
   it('Should figure out single subscription points', () => {
-    const x = cold(        '--a---b---c--|');
-    const xsubs =    '------^-------!';
-    const y = cold(                '---d--e---f---|');
-    const ysubs =    '--------------^-------------!';
-    const e1 = hot(  '------x-------y------|', { x, y });
+    const x = cold('        --a---b---c--|');
+    const xsubs = '   ------^-------!';
+    const y = cold('                ---d--e---f---|');
+    const ysubs = '   --------------^-------------!';
+    const e1 = hot('  ------x-------y------|', { x, y });
     const expected = cold('--------a---b----d--e---f---|');
 
     expect(e1.pipe(switchAll())).toBeObservable(expected);
@@ -95,18 +95,18 @@ Useful, for example, when you want to verify that particular `switchMap` worked 
 The matcher can also accept multiple subscription marbles:
 ```js
   it('Should figure out multiple subscription points', () => {
-    const x = cold(                    '--a---b---c--|');
+    const x = cold('                    --a---b---c--|');
 
-    const y = cold(                '----x---x|', {x});
-    const ySubscription1 =         '----^---!';
+    const y = cold('                ----x---x|', {x});
+    const ySubscription1 = '        ----^---!';
     //                                     '--a---b---c--|'
-    const ySubscription2 =         '--------^------------!';
-    const expectedY = cold(        '------a---a---b---c--|');
+    const ySubscription2 = '        --------^------------!';
+    const expectedY = cold('        ------a---a---b---c--|');
 	
-    const z = cold(                   '-x|', {x});
+    const z = cold('                   -x|', {x});
     //                                 '--a---b---c--|'
-    const zSubscription =             '-^------------!';
-    const expectedZ = cold(           '---a---b---c--|');
+    const zSubscription = '            -^------------!';
+    const expectedZ = cold('           ---a---b---c--|');
 
     expect(y.pipe(switchAll())).toBeObservable(expectedY);
     expect(z.pipe(switchAll())).toBeObservable(expectedZ);

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 import {ColdObservable} from './src/rxjs/cold-observable';
 import {HotObservable} from './src/rxjs/hot-observable';
 import {Scheduler} from './src/rxjs/scheduler';
+import { stripAlignmentChars } from './src/rxjs/strip-alignment-chars';
 
 export type ObservableWithSubscriptions = ColdObservable | HotObservable;
 
@@ -21,15 +22,15 @@ declare global {
 }
 
 export function hot(marbles: string, values?: any, error?: any): HotObservable {
-  return new HotObservable(marbles, values, error);
+  return new HotObservable(stripAlignmentChars(marbles), values, error);
 }
 
 export function cold(marbles: string, values?: any, error?: any): ColdObservable {
-  return new ColdObservable(marbles, values, error);
+  return new ColdObservable(stripAlignmentChars(marbles), values, error);
 }
 
 export function time(marbles: string): number {
-  return Scheduler.get().createTime(marbles);
+  return Scheduler.get().createTime(stripAlignmentChars(marbles));
 }
 
 const dummyResult = {
@@ -40,7 +41,8 @@ const dummyResult = {
 expect.extend({
 
   toHaveSubscriptions(actual: ObservableWithSubscriptions, marbles: string | string[]) {
-    Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(marbles);
+    const sanitizedMarbles = Array.isArray(marbles) ? marbles.map(stripAlignmentChars) : stripAlignmentChars(marbles);
+    Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(sanitizedMarbles);
     return dummyResult;
   },
 
@@ -55,7 +57,7 @@ expect.extend({
   },
 
   toBeMarble(actual: ObservableWithSubscriptions, marbles: string) {
-    Scheduler.get().expectObservable(actual).toBe(marbles);
+    Scheduler.get().expectObservable(actual).toBe(stripAlignmentChars(marbles));
     return dummyResult;
   }
 });

--- a/spec/time.spec.ts
+++ b/spec/time.spec.ts
@@ -13,4 +13,11 @@ describe('', () => {
 
         expect(provided).toBeObservable(expected);
     });
+
+    it('Should ignore whitespace to allow vertical alignment', () => {
+        const referenceDelay = time('-----d|');
+        const alignedDelay = time('  -----d|');
+
+        expect(alignedDelay).toBe(referenceDelay);
+    });
 });

--- a/spec/to-be-marble.spec.ts
+++ b/spec/to-be-marble.spec.ts
@@ -28,4 +28,12 @@ describe('To be marble matcher', () => {
         expect(provided).toBeMarble(expected);
     });
 
+    it('Should ignore whitespace to allow vertical alignment', () => {
+        const hotInput = hot('   --a|');
+        const coldInput = cold(' --a|');
+        const expected = '       --a|';
+
+        expect(hotInput).toBeMarble(expected);
+        expect(coldInput).toBeMarble(expected);
+    });
 });

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -31,7 +31,7 @@ describe('toBeObservable matcher test', () => {
   it('should work for mixed literals', () => {
     const falses$ = cold('--a-----a-----|', {a: false});
     const trues$ = cold('-----b-----b--|', {b: true});
-	const characters$ = cold('-------------c-|')
+	  const characters$ = cold('-------------c-|');
     const expected = cold('--f--t--f--t-c-|', { t: true, f: false, c: 'c' });
     const mapped = merge(falses$, trues$, characters$);
 
@@ -54,4 +54,12 @@ describe('toBeObservable matcher test', () => {
     expect(provided).toBeObservable(expected);
   });
 
+  it('Should ignore whitespace to allow vertical alignment', () => {
+    const hotInput = hot('  ---^--a|');
+    const coldInput = cold('   ---a|');
+    const expected = cold('    ---a|');
+
+    expect(hotInput).toBeObservable(expected);
+    expect(coldInput).toBeObservable(expected);
+  });
 });

--- a/spec/to-have-subscriptions.spec.ts
+++ b/spec/to-have-subscriptions.spec.ts
@@ -48,4 +48,14 @@ describe('toHaveSubscriptions matcher', () => {
   //   const x = cold('--a---b---c--|');
   //   expect(x).not.toHaveNoSubscriptions();
   // });
+
+  it('Should ignore whitespace to allow vertical alignment', () => {
+    const x = hot('          -----a|');
+    const expected = '       -----a|';
+    const xSubscription = '  ^-----!';
+
+    expect(x).toBeMarble(expected);
+    expect(x).toHaveSubscriptions(xSubscription);
+    expect(x).toHaveSubscriptions([xSubscription]);
+  });
 });

--- a/src/rxjs/strip-alignment-chars.ts
+++ b/src/rxjs/strip-alignment-chars.ts
@@ -1,0 +1,3 @@
+export function stripAlignmentChars(marbles: string) {
+  return marbles.replace(/^[ ]+/, '');
+}


### PR DESCRIPTION
This pull request contains a possible implementation for #81 

The TestScheduler of RxJs, which is used under the hood, also implements leading spaces in marble strings. However, this only seems to work when the Observables are created within the callback to `TestScheduler.run(helpers => { ... })`. Outside of the run callback, the implementation treats spaces as a frame advancement (see [this line](https://github.com/ReactiveX/rxjs/blob/master/src/internal/testing/TestScheduler.ts#L187)). It didn't seem easy nor desirable to hack into this to trick the TestScheduler into 'run mode'.

One use case I can see for their conditional space treatment is to support their [time progression syntax](https://github.com/ReactiveX/rxjs/blob/master/doc/marble-testing.md#time-progression-syntax) (`'---- 4ms a 9ms b 9ms (c|)'`), in which spaces need to advance a frame to maintain vertical alignment with other marble strings. However, this use case is still supported with this pull request because I only strip leading spaces.