### PR TITLE
feat(types): keep types as defined in rxjs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,11 +21,23 @@ declare global {
   }
 }
 
-export function hot(marbles: string, values?: any, error?: any): HotObservable {
+export function hot<T = string>(
+  marbles: string,
+  values?: {
+    [marble: string]: T;
+  },
+  error?: any
+): HotObservable<T> {
   return new HotObservable(stripAlignmentChars(marbles), values, error);
 }
 
-export function cold(marbles: string, values?: any, error?: any): ColdObservable {
+export function cold<T = string>(
+  marbles: string,
+  values?: {
+    [marble: string]: T;
+  },
+  error?: any
+): ColdObservable<T> {
   return new ColdObservable(stripAlignmentChars(marbles), values, error);
 }
 

--- a/src/rxjs/cold-observable.ts
+++ b/src/rxjs/cold-observable.ts
@@ -4,9 +4,15 @@ import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 
 import { Scheduler } from './scheduler';
 
-export class ColdObservable extends Observable<any> {
+export class ColdObservable<T = string> extends Observable<any> {
   source: RxJsColdObservable<any>;
-  constructor(public marbles: string, public values?: any[], public error?: any) {
+  constructor(
+    public marbles: string,
+    public values?: {
+      [marble: string]: T;
+    },
+    public error?: any
+  ) {
     super();
 
     this.source = Scheduler.get().createColdObservable(marbles, values, error);

--- a/src/rxjs/hot-observable.ts
+++ b/src/rxjs/hot-observable.ts
@@ -4,9 +4,15 @@ import { SubscriptionLog } from 'rxjs/internal/testing/SubscriptionLog';
 
 import { Scheduler } from './scheduler';
 
-export class HotObservable extends Observable<any> {
+export class HotObservable<T = string> extends Observable<any> {
   source: RxJsHotObservable<any>;
-  constructor(public marbles: string, public values?: any[], public error?: any) {
+  constructor(
+    public marbles: string,
+    public values?: {
+      [marble: string]: T;
+    },
+    public error?: any
+  ) {
     super();
 
     this.source = Scheduler.get().createHotObservable(marbles, values, error);


### PR DESCRIPTION
Hi,
I looked a bit into jest-marbles and I found out that they don't keep types as defined in RxJs.