### PR TITLE
fix(types): add generics to cold/hot, fix .not negation (#551, #15)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,10 +2,11 @@ import { ColdObservable } from './src/rxjs/cold-observable';
 import { HotObservable } from './src/rxjs/hot-observable';
 import { Scheduler } from './src/rxjs/scheduler';
 import { stripAlignmentChars } from './src/rxjs/strip-alignment-chars';
-import { Subscription } from 'rxjs';
+import { assertDeepEqual } from './src/rxjs/assert-deep-equal';
+import { Observable, Subscription } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 
-export type ObservableWithSubscriptions = ColdObservable | HotObservable;
+export type ObservableWithSubscriptions = ColdObservable<any> | HotObservable<any>;
 
 export { Scheduler } from './src/rxjs/scheduler';
 
@@ -36,12 +37,12 @@ declare module 'expect' {
   }
 }
 
-export function hot(marbles: string, values?: object, error?: object): HotObservable {
-  return new HotObservable(stripAlignmentChars(marbles), values, error);
+export function hot<T = unknown>(marbles: string, values?: Record<string, T>, error?: any): HotObservable<T> {
+  return new HotObservable<T>(stripAlignmentChars(marbles), values, error);
 }
 
-export function cold(marbles: string, values?: object, error?: object): ColdObservable {
-  return new ColdObservable(stripAlignmentChars(marbles), values, error);
+export function cold<T = unknown>(marbles: string, values?: Record<string, T>, error?: any): ColdObservable<T> {
+  return new ColdObservable<T>(stripAlignmentChars(marbles), values, error);
 }
 
 export function time(marbles: string): number {
@@ -52,40 +53,76 @@ export function schedule(work: () => void, delay: number): Subscription {
   return Scheduler.get().schedule(work, delay);
 }
 
-const dummyResult = {
+/**
+ * Symbol used to tag flushTest objects that should be asserted as NOT equal.
+ * We tag the object directly so the mark survives independent of array index.
+ */
+const NEGATED = Symbol('jest-marbles-negated');
+
+const dummyPass = {
   message: () => '',
   pass: true,
+};
+
+const dummyFail = {
+  message: () => '',
+  pass: false,
 };
 
 expect.extend({
   toHaveSubscriptions(actual: ObservableWithSubscriptions, marbles: string | string[]) {
     const sanitizedMarbles = Array.isArray(marbles) ? marbles.map(stripAlignmentChars) : stripAlignmentChars(marbles);
+    if (this.isNot) {
+      const flushTests: any[] = Scheduler.get()['flushTests'];
+      // Register the flush test first, then tag the object that was just added.
+      Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(sanitizedMarbles);
+      flushTests[flushTests.length - 1][NEGATED] = true;
+      return dummyFail;
+    }
     Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(sanitizedMarbles);
-    return dummyResult;
+    return dummyPass;
   },
 
   toHaveNoSubscriptions(actual: ObservableWithSubscriptions) {
+    if (this.isNot) {
+      throw new Error('toHaveNoSubscriptions cannot be negated — use toHaveSubscriptions instead');
+    }
     Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe([]);
-    return dummyResult;
+    return dummyPass;
   },
 
-  toBeObservable(actual, expected: ObservableWithSubscriptions) {
+  toBeObservable(actual: Observable<unknown>, expected: ObservableWithSubscriptions) {
+    if (this.isNot) {
+      const flushTests: any[] = Scheduler.get()['flushTests'];
+      Scheduler.get().expectObservable(actual).toBe(expected.marbles, expected.values, expected.error);
+      flushTests[flushTests.length - 1][NEGATED] = true;
+      return dummyFail;
+    }
     Scheduler.get().expectObservable(actual).toBe(expected.marbles, expected.values, expected.error);
-    return dummyResult;
+    return dummyPass;
   },
 
   toBeMarble(actual: ObservableWithSubscriptions, marbles: string) {
+    if (this.isNot) {
+      const flushTests: any[] = Scheduler.get()['flushTests'];
+      Scheduler.get().expectObservable(actual).toBe(stripAlignmentChars(marbles));
+      flushTests[flushTests.length - 1][NEGATED] = true;
+      return dummyFail;
+    }
     Scheduler.get().expectObservable(actual).toBe(stripAlignmentChars(marbles));
-    return dummyResult;
+    return dummyPass;
   },
 
   toSatisfyOnFlush(actual: ObservableWithSubscriptions, func: () => void) {
+    if (this.isNot) {
+      throw new Error('toSatisfyOnFlush cannot be negated');
+    }
     Scheduler.get().expectObservable(actual);
     // tslint:disable:no-string-literal
     const flushTests = Scheduler.get()['flushTests'];
     flushTests[flushTests.length - 1].ready = true;
     onFlush.push(func);
-    return dummyResult;
+    return dummyPass;
   },
 });
 
@@ -95,10 +132,50 @@ beforeEach(() => {
   Scheduler.init();
   onFlush = [];
 });
+
 afterEach(() => {
-  Scheduler.get().run(() => {
+  const scheduler = Scheduler.get();
+  const flushTests: any[] = scheduler['flushTests'];
+  const hasNegated = flushTests.some((t) => t[NEGATED]);
+
+  if (hasNegated) {
+    // Replace assertDeepEqual with a wrapper that inverts the check for negated tests.
+    // The wrapper is called once per ready flushTest, in the same order as flushTests.
+    // We use a WeakSet of tagged test objects so we can look up the tag by object identity.
+    const negatedSet = new WeakSet<object>(flushTests.filter((t) => t[NEGATED]));
+    // Track which flushTest object is currently being processed.
+    // We walk through flushTests in order and match each assertDeepEqual call to its test.
+    const readyTests = flushTests.filter((t) => t.ready);
+    let callIndex = 0;
+
+    (scheduler as any).assertDeepEqual = (actual: any, expected: any) => {
+      const test = readyTests[callIndex++];
+      if (test && negatedSet.has(test)) {
+        // Negated assertion: succeed if actual ≠ expected, fail if they're equal.
+        let threw = false;
+        try {
+          assertDeepEqual(actual, expected);
+        } catch {
+          threw = true;
+        }
+        if (!threw) {
+          throw new Error(
+            'Expected observables to differ, but they matched.\n' +
+              `  Received: ${JSON.stringify(actual)}\n` +
+              `  Not expected: ${JSON.stringify(expected)}`
+          );
+        }
+        // They differ → .not passes → do nothing (swallow the would-be failure).
+      } else {
+        assertDeepEqual(actual, expected);
+      }
+    };
+  }
+
+  scheduler.run(() => {
     TestScheduler.frameTimeFactor = 10;
   });
+
   while (onFlush.length > 0) {
     onFlush.shift()?.();
   }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,18 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "testRegex": "/spec/.*\\.(ts|tsx|js)$"
+    "testRegex": "/spec/.*\\.(ts|tsx|js)$",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/.claude/"
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsconfig": {
+          "types": ["jest", "node"]
+        }
+      }
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "19.8.1",

--- a/package.json
+++ b/package.json
@@ -70,18 +70,17 @@
     ]
   },
   "jest": {
-    "preset": "ts-jest",
     "testRegex": "/spec/.*\\.(ts|tsx|js)$",
     "testPathIgnorePatterns": [
       "/node_modules/",
       "/.claude/"
     ],
-    "globals": {
-      "ts-jest": {
+    "transform": {
+      "^.+\\.tsx?$": ["ts-jest", {
         "tsconfig": {
           "types": ["jest", "node"]
         }
-      }
+      }]
     }
   },
   "devDependencies": {

--- a/spec/generics.spec.ts
+++ b/spec/generics.spec.ts
@@ -1,0 +1,29 @@
+import { cold, hot } from '../index';
+
+interface MyEvent {
+  type: string;
+  payload: number;
+}
+
+describe('cold() and hot() generics (#551)', () => {
+  it('cold<T> infers the value type from the values record', () => {
+    const event: MyEvent = { type: 'click', payload: 42 };
+    // TypeScript should infer ColdObservable<MyEvent> — if cold() did not have
+    // the generic, passing a typed values map would require a cast to `object`.
+    const obs$ = cold<MyEvent>('-a|', { a: event });
+    // The source observable carries the right element type
+    expect(obs$).toBeObservable(cold<MyEvent>('-a|', { a: event }));
+  });
+
+  it('hot<T> infers the value type from the values record', () => {
+    const event: MyEvent = { type: 'click', payload: 42 };
+    const obs$ = hot<MyEvent>('-a|', { a: event });
+    expect(obs$).toBeObservable(cold<MyEvent>('-a|', { a: event }));
+  });
+
+  it('cold() without explicit T defaults to unknown and accepts any value', () => {
+    // Should compile without errors even when values are mixed types
+    const obs$ = cold('-a-b|', { a: 1, b: 'two' });
+    expect(obs$).toBeObservable(cold('-a-b|', { a: 1, b: 'two' }));
+  });
+});

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -113,8 +113,21 @@ describe('toBeObservable matcher test', () => {
     expect(source).toBeObservable(expected);
   });
 
-  // TODO: uncomment once .not.toBeObservable works
-  // it('Should fail on different errors', () => {
-  //   expect(cold('#', {}, 'A')).not.toBeObservable(cold('#', {}, 'B'))
-  // })
+  describe('.not negation', () => {
+    it('Should pass when observables differ (different marble strings)', () => {
+      expect(cold('-a|')).not.toBeObservable(cold('-b|'));
+    });
+
+    it('Should pass when observables differ (different timing)', () => {
+      expect(cold('-a|')).not.toBeObservable(cold('--a|'));
+    });
+
+    it('Should pass on different errors', () => {
+      expect(cold('#', {}, 'A')).not.toBeObservable(cold('#', {}, 'B'));
+    });
+
+    it('Should pass when hot observable differs from cold', () => {
+      expect(hot('-a-|')).not.toBeObservable(cold('--a|'));
+    });
+  });
 });

--- a/spec/to-have-subscriptions.spec.ts
+++ b/spec/to-have-subscriptions.spec.ts
@@ -43,11 +43,6 @@ describe('toHaveSubscriptions matcher', () => {
     expect(x).toHaveNoSubscriptions();
   });
 
-  // it('Should verify that there is at least one subscription', () => {
-  //   const x = cold('--a---b---c--|');
-  //   expect(x).not.toHaveNoSubscriptions();
-  // });
-
   it('Should ignore whitespace to allow vertical alignment', () => {
     const x = hot('          -----a|');
     const expected = '       -----a|';
@@ -56,5 +51,24 @@ describe('toHaveSubscriptions matcher', () => {
     expect(x).toBeMarble(expected);
     expect(x).toHaveSubscriptions(xSubscription);
     expect(x).toHaveSubscriptions([xSubscription]);
+  });
+
+  describe('.not negation', () => {
+    it('Should pass when observable has different subscription points than asserted', () => {
+      const x = cold('--a---b---c--|');
+      const y = cold('----x|', { x });
+      const wrongSub = '----^--------!';
+
+      expect(y.pipe(switchAll())).toBeMarble('------a---b---c--|');
+      // x is subscribed at frame 4 (when y emits x), not matching wrongSub
+      expect(x).not.toHaveSubscriptions(wrongSub);
+    });
+
+    it('toHaveNoSubscriptions should throw when negated', () => {
+      const x = cold('--a|');
+      expect(() => {
+        expect(x).not.toHaveNoSubscriptions();
+      }).toThrow('toHaveNoSubscriptions cannot be negated');
+    });
   });
 });

--- a/spec/to-satisfy-on-flush.spec.ts
+++ b/spec/to-satisfy-on-flush.spec.ts
@@ -9,4 +9,13 @@ describe('toSatisfyOnFlush', () => {
       expect(mock).toHaveBeenCalledTimes(4);
     });
   });
+
+  it('should throw when negated', () => {
+    const stream$ = cold('a|');
+    expect(() => {
+      expect(stream$).not.toSatisfyOnFlush(() => {
+        // intentionally empty
+      });
+    }).toThrow('toSatisfyOnFlush cannot be negated');
+  });
 });

--- a/src/rxjs/cold-observable.ts
+++ b/src/rxjs/cold-observable.ts
@@ -1,19 +1,19 @@
 import { Observable } from 'rxjs';
-import { TestScheduler } from 'rxjs/testing';
+import { ColdObservable as RxColdObservable } from 'rxjs/internal/testing/ColdObservable';
 import { SubscriptionLog } from '../rxjs/types';
 
 import { Scheduler } from './scheduler';
 
-export class ColdObservable extends Observable<any> {
-  source: ReturnType<TestScheduler['createColdObservable']>;
+export class ColdObservable<T = unknown> extends Observable<T> {
+  source: RxColdObservable<T>;
   constructor(
     public marbles: string,
-    public values?: Record<string, any>,
+    public values?: Record<string, T>,
     public error?: any
   ) {
     super();
 
-    this.source = Scheduler.get().createColdObservable(marbles, values, error);
+    this.source = Scheduler.get().createColdObservable<T>(marbles, values, error);
   }
 
   getSubscriptions(): SubscriptionLog[] {

--- a/src/rxjs/hot-observable.ts
+++ b/src/rxjs/hot-observable.ts
@@ -1,19 +1,19 @@
 import { Observable } from 'rxjs';
-import { TestScheduler } from 'rxjs/testing';
+import { HotObservable as RxHotObservable } from 'rxjs/internal/testing/HotObservable';
 import { SubscriptionLog } from '../rxjs/types';
 
 import { Scheduler } from './scheduler';
 
-export class HotObservable extends Observable<any> {
-  source: ReturnType<TestScheduler['createHotObservable']>;
+export class HotObservable<T = unknown> extends Observable<T> {
+  source: RxHotObservable<T>;
   constructor(
     public marbles: string,
-    public values?: Record<string, any>,
+    public values?: Record<string, T>,
     public error?: any
   ) {
     super();
 
-    this.source = Scheduler.get().createHotObservable(marbles, values, error);
+    this.source = Scheduler.get().createHotObservable<T>(marbles, values, error);
   }
 
   getSubscriptions(): SubscriptionLog[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
       "es2017",
       "es2020"
     ],
+    "types": ["jest"],
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What was broken

### #551 — Type regression in `cold()`/`hot()`

Between 3.0.6 and 3.1.0, `cold()` and `hot()` lost their value-type parameter, silently regressing to `values?: object`. This broke user builds whenever typed values were passed:

```ts
// Previously compiled; now fails with TS2345 in 3.1.0
const obs$ = cold<MyEvent>('-a|', { a: myEvent });
```

### #15 — Broken `.not` negation

All matchers returned a hardcoded `{pass: true}` synchronously, then registered the real assertion with the TestScheduler for deferred flush. Two consequences:

1. Jest's `.not` inverted the always-true dummy → immediately threw with an empty message string, never reaching the deferred assertion.
2. The deferred assertion ran as a positive equality check regardless of `.not`.

## How it's fixed

### Generics (#551)

- `ColdObservable<T = unknown>` and `HotObservable<T = unknown>` are now generic, with `source` typed as `RxColdObservable<T>` / `RxHotObservable<T>` from `rxjs/internal/testing/`.
- `cold<T = unknown>()` and `hot<T = unknown>()` in `index.ts` forward the generic to the constructors.
- `ObservableWithSubscriptions` is `ColdObservable<any> | HotObservable<any>` so it remains assignable from all concrete instances.
- Default `T = unknown` keeps strict mode happy while not breaking untyped usage.

### `.not` negation (#15)

- Under `this.isNot`, matchers return `{pass: false}` so Jest's synchronous inversion resolves without throwing.
- FlushTest objects are tagged with a `Symbol` at registration time.
- In `afterEach`, the scheduler's `assertDeepEqual` instance property is replaced with a wrapper that inverts checks for tagged tests: if actual equals expected (no throw from `assertDeepEqual`), the negated assertion fails with a clear message; if they differ (throw), the error is swallowed so `.not` passes.
- `toSatisfyOnFlush` and `toHaveNoSubscriptions` throw synchronously under `.not` with descriptive messages since negation is semantically undefined for them.

## Additional fixes required to make `yarn ci` pass

- **`tsconfig.json`**: Added `"types": ["jest"]` (TypeScript 6 no longer auto-includes `@types/*`; required for both DTS build and test compilation) and `"ignoreDeprecations": "6.0"` (suppresses TS6 deprecation errors for `moduleResolution: node` and `target: es5`).
- **`package.json` jest config**: Added `ts-jest` globals with `types: ["jest", "node"]` so unit tests compile cleanly, and `testPathIgnorePatterns: ["/.claude/"]` to prevent jest from discovering spec files inside git worktrees.

## Test plan

- [ ] Existing 53 unit tests all pass
- [ ] New `spec/generics.spec.ts` — 3 tests covering typed `cold<T>`/`hot<T>` usage
- [ ] New `.not.toBeObservable()` tests — 4 cases (different marbles, timing, errors, hot vs cold)
- [ ] New `.not.toHaveSubscriptions()` test — passes when subscriptions differ
- [ ] `toHaveNoSubscriptions` throws when negated
- [ ] `toSatisfyOnFlush` throws when negated
- [ ] `yarn ci` passes end-to-end (eslint + 63 unit tests + tsup build + e2e)