### PR TITLE
ci: add tag-triggered CD workflow for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write  # required for npm OIDC (Trusted Publishers)
     steps:
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'  # wires OIDC token via NODE_AUTH_TOKEN
 
       - name: Enable Corepack
         run: corepack enable
@@ -27,6 +29,4 @@ jobs:
         run: yarn ci
 
       - name: Publish to npm
-        run: yarn npm publish
-        env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build and test
+        run: yarn ci
+
+      - name: Publish to npm
+        run: yarn npm publish
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — triggers on `v*` tag push and runs `yarn npm publish`
- Adds `testPathIgnorePatterns: ["/.claude/"]` to jest config to prevent agent worktrees from leaking into test discovery

## How it works

The release flow stays local (`yarn release` does the version bump, GPG-signed commit + tag, and `git push --follow-tags`). When CI sees the tag push, it:

1. Installs deps (`yarn --immutable`)
2. Runs the full gate (`yarn ci`) before touching the registry
3. Publishes via `yarn npm publish` using `YARN_NPM_AUTH_TOKEN`

No commit push-back from CI — versioning stays in the maintainer's hands.

## Setup required

Add `NPM_TOKEN` (automation token from npmjs.com) as a repository secret:  
**Settings → Secrets and variables → Actions → New repository secret**