### PR TITLE
fix(build): remove ignoreDeprecations 6.0, invalid in TS5.9

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
       "es2020"
     ],
     "types": ["jest"],
-    "ignoreDeprecations": "6.0",
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Agent A added this preemptively for TS6 but it breaks the tsup DTS build on TS5.9 with `error TS5103: Invalid value for '--ignoreDeprecations'`. Remove now; it will be added back when #656 (TS6 upgrade) lands.