### PR TITLE
fix(ci): remove registry-url from setup-node, interferes with OIDC auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'  # wires OIDC token via NODE_AUTH_TOKEN
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
setup-node's registry-url creates a .npmrc with _authToken=${NODE_AUTH_TOKEN} — npm uses that classic auth path instead of doing the OIDC token exchange for Trusted Publishers. Removing it; publishConfig.registry in package.json already specifies the target registry.