### PR TITLE
feat!: time progression / run mode (v4) — closes #117

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ v4 runs rxjs's `TestScheduler` in **run mode**:
 - **Time operators use real virtual time.** For example, `debounceTime(250)` on
   `cold('a 250ms b|')` yields `cold('250ms a 1ms (b|)')` — `a` debounces out
   at 250ms and `b` flushes on completion 1ms later.
-- **New `marbleTest`** for tests that need `animate()`, virtualized
-  `setTimeout`/`Date.now`, or imperative time control:
+- **New `marbleTest`** for tests that need `animate()`, or that exercise
+  operators using RxJS's default scheduler (`delay`, `timer`, `interval`,
+  `debounceTime`, …) so they resolve against virtual time. Note: it virtualizes
+  RxJS's own schedulers, **not** the global `setTimeout`/`Date.now` — raw calls
+  to those in code under test still run in real time.
 
 ```js
 it('drives animationFrames', marbleTest(() => {
@@ -208,7 +211,7 @@ Use `Nms`, `Ns`, or `Nm` inside a marble string to express large durations witho
 ```
 
 ## marbleTest
-Wraps a test body in a real `TestScheduler.run()` context. Use this when you need `animate()`, virtualized `setTimeout`/`Date.now`, or imperative time control. Pass the return value directly to `it`:
+Wraps a test body in a real `TestScheduler.run()` context. Use this when you need `animate()`, or when the code under test uses operators backed by RxJS's default scheduler (`delay`, `timer`, `interval`, `debounceTime`, …) and you want them to resolve against virtual time. It virtualizes RxJS's schedulers only — not the global `setTimeout`/`Date.now`. Pass the return value directly to `it`:
 ```js
   it(
     'runs assertions inside a real run() context',

--- a/README.md
+++ b/README.md
@@ -15,8 +15,28 @@ This library will help you to test your reactive code in easy and clear way.
  - RxJs
  - Familiarity with [marbles syntax](https://rxjs.dev/guide/testing/marble-testing#marble-syntax)
 
-# Not supported (but planning to)
- - Time progression syntax
+# v4 migration (run mode)
+
+v4 runs rxjs's `TestScheduler` in **run mode**:
+
+- **Frames are 1ms each (was 10).** `time('--|')` now returns `2`, not `20`.
+  Re-baseline any hard-coded frame numbers.
+- **Marble diagrams are unchanged** — `cold('--a--b|')` vs `cold('--a--b|')`
+  still passes; both sides shift by the same factor.
+- **`TestScheduler.frameTimeFactor` is no longer honored.** Express durations
+  with time-progression syntax: `cold('a 250ms b|')`.
+- **Time operators use real virtual time.** For example, `debounceTime(250)` on
+  `cold('a 250ms b|')` yields `cold('250ms a 1ms (b|)')` — `a` debounces out
+  at 250ms and `b` flushes on completion 1ms later.
+- **New `marbleTest`** for tests that need `animate()`, virtualized
+  `setTimeout`/`Date.now`, or imperative time control:
+
+```js
+it('drives animationFrames', marbleTest(() => {
+  animate('--x--x');
+  expect(source$).toBeObservable(cold('--a--(b|)'));
+}));
+```
 
 # Usage
 
@@ -38,7 +58,7 @@ npm i jest-marbles@1 -D
 In the test file:
 
 ```js
-import {cold, hot, time, schedule} from 'jest-marbles';
+import { cold, hot, time, schedule, marbleTest, animate } from 'jest-marbles';
 ```
 
 Inside the test:
@@ -176,6 +196,43 @@ Allows you to schedule task on specified frame
 
     expect(source).toBeObservable(expected);
   });
+```
+
+## time-progression syntax
+Use `Nms`, `Ns`, or `Nm` inside a marble string to express large durations without drawing every frame:
+```js
+  it('debounces emissions', marbleTest(() => {
+    const src = cold('a 250ms b|');
+    expect(src.pipe(debounceTime(250))).toBeObservable(cold('250ms a 1ms (b|)'));
+  }));
+```
+
+## marbleTest
+Wraps a test body in a real `TestScheduler.run()` context. Use this when you need `animate()`, virtualized `setTimeout`/`Date.now`, or imperative time control. Pass the return value directly to `it`:
+```js
+  it(
+    'runs assertions inside a real run() context',
+    marbleTest(() => {
+      const src = cold('a 250ms b|');
+      expect(src.pipe(debounceTime(250))).toBeObservable(cold('250ms a 1ms (b|)'));
+    })
+  );
+```
+
+## animate
+Only valid inside `marbleTest`. Drives `animationFrames`-based timing by scheduling virtual animation-frame ticks at the positions marked in the marble string:
+```js
+  it(
+    'drives animationFrames-based timing',
+    marbleTest(() => {
+      animate('--x--x');
+      const src = animationFrames().pipe(
+        map(({ elapsed }) => elapsed),
+        take(2)
+      );
+      expect(src).toBeObservable(cold('--a--(b|)', { a: 2, b: 5 }));
+    })
+  );
 ```
 
 

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export type ObservableWithSubscriptions = ColdObservable<any> | HotObservable<an
 
 export { Scheduler } from './src/rxjs/scheduler';
 export { marbleTest } from './src/marble-test';
+export { animate } from './src/animate';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,7 @@ import { ColdObservable } from './src/rxjs/cold-observable';
 import { HotObservable } from './src/rxjs/hot-observable';
 import { Scheduler } from './src/rxjs/scheduler';
 import { stripAlignmentChars } from './src/rxjs/strip-alignment-chars';
-import { assertDeepEqual } from './src/rxjs/assert-deep-equal';
 import { Observable, Subscription } from 'rxjs';
-import { TestScheduler } from 'rxjs/testing';
 
 export type ObservableWithSubscriptions = ColdObservable<any> | HotObservable<any>;
 
@@ -53,12 +51,6 @@ export function schedule(work: () => void, delay: number): Subscription {
   return Scheduler.get().schedule(work, delay);
 }
 
-/**
- * Symbol used to tag flushTest objects that should be asserted as NOT equal.
- * We tag the object directly so the mark survives independent of array index.
- */
-const NEGATED = Symbol('jest-marbles-negated');
-
 const dummyPass = {
   message: () => '',
   pass: true,
@@ -73,10 +65,8 @@ expect.extend({
   toHaveSubscriptions(actual: ObservableWithSubscriptions, marbles: string | string[]) {
     const sanitizedMarbles = Array.isArray(marbles) ? marbles.map(stripAlignmentChars) : stripAlignmentChars(marbles);
     if (this.isNot) {
-      const flushTests: any[] = Scheduler.get()['flushTests'];
-      // Register the flush test first, then tag the object that was just added.
       Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(sanitizedMarbles);
-      flushTests[flushTests.length - 1][NEGATED] = true;
+      Scheduler.markLastNegated();
       return dummyFail;
     }
     Scheduler.get().expectSubscriptions(actual.getSubscriptions()).toBe(sanitizedMarbles);
@@ -93,9 +83,8 @@ expect.extend({
 
   toBeObservable(actual: Observable<unknown>, expected: ObservableWithSubscriptions) {
     if (this.isNot) {
-      const flushTests: any[] = Scheduler.get()['flushTests'];
       Scheduler.get().expectObservable(actual).toBe(expected.marbles, expected.values, expected.error);
-      flushTests[flushTests.length - 1][NEGATED] = true;
+      Scheduler.markLastNegated();
       return dummyFail;
     }
     Scheduler.get().expectObservable(actual).toBe(expected.marbles, expected.values, expected.error);
@@ -104,9 +93,8 @@ expect.extend({
 
   toBeMarble(actual: ObservableWithSubscriptions, marbles: string) {
     if (this.isNot) {
-      const flushTests: any[] = Scheduler.get()['flushTests'];
       Scheduler.get().expectObservable(actual).toBe(stripAlignmentChars(marbles));
-      flushTests[flushTests.length - 1][NEGATED] = true;
+      Scheduler.markLastNegated();
       return dummyFail;
     }
     Scheduler.get().expectObservable(actual).toBe(stripAlignmentChars(marbles));
@@ -118,66 +106,16 @@ expect.extend({
       throw new Error('toSatisfyOnFlush cannot be negated');
     }
     Scheduler.get().expectObservable(actual);
-    // tslint:disable:no-string-literal
-    const flushTests = Scheduler.get()['flushTests'];
-    flushTests[flushTests.length - 1].ready = true;
-    onFlush.push(func);
+    Scheduler.markLastReady();
+    Scheduler.queueOnFlush(func);
     return dummyPass;
   },
 });
 
-let onFlush: (() => void)[] = [];
-
 beforeEach(() => {
   Scheduler.init();
-  onFlush = [];
 });
 
 afterEach(() => {
-  const scheduler = Scheduler.get();
-  const flushTests: any[] = scheduler['flushTests'];
-  const hasNegated = flushTests.some((t) => t[NEGATED]);
-
-  if (hasNegated) {
-    // Replace assertDeepEqual with a wrapper that inverts the check for negated tests.
-    // The wrapper is called once per ready flushTest, in the same order as flushTests.
-    // We use a WeakSet of tagged test objects so we can look up the tag by object identity.
-    const negatedSet = new WeakSet<object>(flushTests.filter((t) => t[NEGATED]));
-    // Track which flushTest object is currently being processed.
-    // We walk through flushTests in order and match each assertDeepEqual call to its test.
-    const readyTests = flushTests.filter((t) => t.ready);
-    let callIndex = 0;
-
-    (scheduler as any).assertDeepEqual = (actual: any, expected: any) => {
-      const test = readyTests[callIndex++];
-      if (test && negatedSet.has(test)) {
-        // Negated assertion: succeed if actual ≠ expected, fail if they're equal.
-        let threw = false;
-        try {
-          assertDeepEqual(actual, expected);
-        } catch {
-          threw = true;
-        }
-        if (!threw) {
-          throw new Error(
-            'Expected observables to differ, but they matched.\n' +
-              `  Received: ${JSON.stringify(actual)}\n` +
-              `  Not expected: ${JSON.stringify(expected)}`
-          );
-        }
-        // They differ → .not passes → do nothing (swallow the would-be failure).
-      } else {
-        assertDeepEqual(actual, expected);
-      }
-    };
-  }
-
-  scheduler.run(() => {
-    TestScheduler.frameTimeFactor = 10;
-  });
-
-  while (onFlush.length > 0) {
-    onFlush.shift()?.();
-  }
-  Scheduler.reset();
+  Scheduler.teardown();
 });

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import { Observable, Subscription } from 'rxjs';
 export type ObservableWithSubscriptions = ColdObservable<any> | HotObservable<any>;
 
 export { Scheduler } from './src/rxjs/scheduler';
+export { marbleTest } from './src/marble-test';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/spec/animate.spec.ts
+++ b/spec/animate.spec.ts
@@ -1,0 +1,21 @@
+import { animationFrames } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+import { animate, cold, marbleTest } from '../index';
+
+describe('animate', () => {
+  it('throws when used outside marbleTest', () => {
+    expect(() => animate('--x')).toThrow('animate() can only be used inside marbleTest()');
+  });
+
+  it(
+    'drives animationFrames-based timing inside marbleTest',
+    marbleTest(() => {
+      animate('--x--x');
+      const src = animationFrames().pipe(
+        map(({ elapsed }) => elapsed),
+        take(2)
+      );
+      expect(src).toBeObservable(cold('--a--(b|)', { a: 2, b: 5 }));
+    })
+  );
+});

--- a/spec/marble-test-fake-async.spec.ts
+++ b/spec/marble-test-fake-async.spec.ts
@@ -1,4 +1,4 @@
-import { delay, of } from 'rxjs';
+import { delay, of, timestamp } from 'rxjs';
 import { cold, marbleTest } from '../index';
 
 describe('marbleTest fake async', () => {
@@ -7,6 +7,18 @@ describe('marbleTest fake async', () => {
     marbleTest(() => {
       // of('x') emits synchronously at frame 0; delay(5) shifts to frame 5 in virtual time
       expect(of('x').pipe(delay(5))).toBeObservable(cold('5ms (x|)'));
+    })
+  );
+
+  it(
+    'virtualizes the RxJS clock (Date.now equivalent) for the system under test',
+    marbleTest(() => {
+      // timestamp() reads dateTimestampProvider.now(), which TestScheduler.run() virtualizes.
+      // After a 5ms delay, the virtual clock reads 5 — so timestamp is 5.
+      // NOTE: raw setTimeout / Date.now() are NOT virtualized (only RxJS scheduler-based
+      // operators use the patched providers). This test confirms the RxJS clock path.
+      const source = of('x').pipe(delay(5), timestamp());
+      expect(source).toBeObservable(cold('5ms (a|)', { a: { value: 'x', timestamp: 5 } }));
     })
   );
 });

--- a/spec/marble-test-fake-async.spec.ts
+++ b/spec/marble-test-fake-async.spec.ts
@@ -1,0 +1,12 @@
+import { delay, of } from 'rxjs';
+import { cold, marbleTest } from '../index';
+
+describe('marbleTest fake async', () => {
+  it(
+    'virtualizes delay() (which uses the default async scheduler)',
+    marbleTest(() => {
+      // of('x') emits synchronously at frame 0; delay(5) shifts to frame 5 in virtual time
+      expect(of('x').pipe(delay(5))).toBeObservable(cold('5ms (x|)'));
+    })
+  );
+});

--- a/spec/marble-test-negation.spec.ts
+++ b/spec/marble-test-negation.spec.ts
@@ -1,4 +1,4 @@
-import { cold, marbleTest } from '../index';
+import { cold, marbleTest, Scheduler } from '../index';
 
 describe('marbleTest negation', () => {
   it(
@@ -13,5 +13,14 @@ describe('marbleTest negation', () => {
       expect(cold('--a|')).not.toBeObservable(cold('--a|'));
     });
     expect(run).toThrow(/Expected observables to differ/);
+  });
+
+  it('throws exactly once — no residual assertion leaks into teardown', () => {
+    const run = marbleTest(() => {
+      expect(cold('--a|')).not.toBeObservable(cold('--a|'));
+    });
+    expect(run).toThrow(/Expected observables to differ/);
+    // The global afterEach flushes via Scheduler.get().run(() => {}); it must be a no-op now.
+    expect(() => Scheduler.get().run(() => {})).not.toThrow();
   });
 });

--- a/spec/marble-test-negation.spec.ts
+++ b/spec/marble-test-negation.spec.ts
@@ -1,0 +1,17 @@
+import { cold, marbleTest } from '../index';
+
+describe('marbleTest negation', () => {
+  it(
+    'passes when observables differ under .not',
+    marbleTest(() => {
+      expect(cold('--a|')).not.toBeObservable(cold('--b|'));
+    })
+  );
+
+  it('fails when observables match under .not', () => {
+    const run = marbleTest(() => {
+      expect(cold('--a|')).not.toBeObservable(cold('--a|'));
+    });
+    expect(run).toThrow(/Expected observables to differ/);
+  });
+});

--- a/spec/marble-test.spec.ts
+++ b/spec/marble-test.spec.ts
@@ -1,0 +1,19 @@
+import { debounceTime } from 'rxjs';
+import { cold, marbleTest } from '../index';
+
+describe('marbleTest', () => {
+  it(
+    'runs jest-marbles assertions inside a real run() context',
+    marbleTest(() => {
+      const src = cold('a 250ms b|');
+      expect(src.pipe(debounceTime(250))).toBeObservable(cold('250ms a 1ms (b|)'));
+    })
+  );
+
+  it.skip(
+    'composes with jest modifiers',
+    marbleTest(() => {
+      expect(cold('--a|')).toBeObservable(cold('--a|'));
+    })
+  );
+});

--- a/spec/marblizer.spec.ts
+++ b/spec/marblizer.spec.ts
@@ -3,14 +3,14 @@ import { Marblizer } from '../src/marblizer';
 
 describe('Marblizer test', () => {
   it('Should marblize TestMessages', () => {
-    // First dash is frame 0
+    // First dash is frame 0; frames are 1ms each (frameStep = 1)
     // ---(be)----c-f-----|
     const sample: TestMessages = [
-      { frame: 30, notification: { kind: 'N', value: 'b' } },
-      { frame: 30, notification: { kind: 'N', value: 'e' } },
-      { frame: 110, notification: { kind: 'N', value: 'c' } },
-      { frame: 130, notification: { kind: 'N', value: 'f' } },
-      { frame: 190, notification: { kind: 'C' } },
+      { frame: 3, notification: { kind: 'N', value: 'b' } },
+      { frame: 3, notification: { kind: 'N', value: 'e' } },
+      { frame: 11, notification: { kind: 'N', value: 'c' } },
+      { frame: 13, notification: { kind: 'N', value: 'f' } },
+      { frame: 19, notification: { kind: 'C' } },
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -19,9 +19,9 @@ describe('Marblizer test', () => {
 
   it('Should marblize TestMessages with error', () => {
     const sample: TestMessages = [
-      { frame: 30, notification: { kind: 'N', value: 'b' } },
-      { frame: 30, notification: { kind: 'N', value: 'e' } },
-      { frame: 110, notification: { kind: 'E', error: null } },
+      { frame: 3, notification: { kind: 'N', value: 'b' } },
+      { frame: 3, notification: { kind: 'N', value: 'e' } },
+      { frame: 11, notification: { kind: 'E', error: null } },
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -30,8 +30,8 @@ describe('Marblizer test', () => {
 
   it('Should marblize TestMessages without completion', () => {
     const sample: TestMessages = [
-      { frame: 30, notification: { kind: 'N', value: 'b' } },
-      { frame: 110, notification: { kind: 'N', value: 'e' } },
+      { frame: 3, notification: { kind: 'N', value: 'b' } },
+      { frame: 11, notification: { kind: 'N', value: 'e' } },
     ];
 
     const marble = Marblizer.marblize(sample);
@@ -39,14 +39,14 @@ describe('Marblizer test', () => {
   });
 
   it('Should marblize Subscriptions without completion', () => {
-    const sample: SubscriptionLog[] = [{ subscribedFrame: 20, unsubscribedFrame: Infinity }];
+    const sample: SubscriptionLog[] = [{ subscribedFrame: 2, unsubscribedFrame: Infinity }];
 
     const marble = Marblizer.marblizeSubscriptions(sample);
     expect(marble).toEqual(['--^']);
   });
 
   it('Should marblize TestMessages without emission (but with completion)', () => {
-    const sample: TestMessages = [{ frame: 110, notification: { kind: 'C' } }];
+    const sample: TestMessages = [{ frame: 11, notification: { kind: 'C' } }];
 
     const marble = Marblizer.marblize(sample);
     expect(marble).toEqual('-----------|');
@@ -54,8 +54,8 @@ describe('Marblizer test', () => {
 
   it('Should marblize SubscriptionLogs', () => {
     const marble = Marblizer.marblizeSubscriptions([
-      { subscribedFrame: 30, unsubscribedFrame: 60 },
-      { subscribedFrame: 10, unsubscribedFrame: 50 },
+      { subscribedFrame: 3, unsubscribedFrame: 6 },
+      { subscribedFrame: 1, unsubscribedFrame: 5 },
     ]);
     expect(marble).toEqual(['---^--!', '-^---!']);
   });

--- a/spec/run-mode-timing.spec.ts
+++ b/spec/run-mode-timing.spec.ts
@@ -1,0 +1,21 @@
+import { debounceTime } from 'rxjs';
+import { cold, time } from '../index';
+
+describe('run-mode timing', () => {
+  it('time() counts 1ms per frame char', () => {
+    expect(time('-----|')).toBe(5);
+  });
+
+  it('parses time-progression syntax', () => {
+    const src = cold('a 250ms b|');
+    const expected = cold('a 250ms b|');
+    expect(src).toBeObservable(expected);
+  });
+
+  it('virtualizes debounceTime against real durations', () => {
+    const src = cold('a 250ms b|');
+    // debounceTime(250) emits 'a' at 250ms (debounce fires), then 'b' at 252ms (source
+    // completes at 251ms flushing the buffered value, but after the +1ms debounce reset)
+    expect(src.pipe(debounceTime(250))).toBeObservable(cold('250ms a 1ms (b|)'));
+  });
+});

--- a/spec/to-be-observable.spec.ts
+++ b/spec/to-be-observable.spec.ts
@@ -89,14 +89,16 @@ describe('toBeObservable matcher test', () => {
 
     schedule(() => source.next('a'), 1);
     schedule(() => source.next('b'), 2);
-    const expected = cold('ab');
+    // With 1ms frames: schedule(fn, 1) fires at 1ms (frame 1), schedule(fn, 2) at 2ms (frame 2)
+    const expected = cold('-ab');
 
     expect(source).toBeObservable(expected);
   });
 
   it('Should work with delays', () => {
     const source = cold('a');
-    const expected = cold('--a');
+    // delay(20) shifts by 20ms; with 1ms frames the expected marble uses time-progression syntax
+    const expected = cold('20ms a');
 
     expect(source.pipe(delay(20))).toBeObservable(expected);
   });

--- a/src/animate.ts
+++ b/src/animate.ts
@@ -1,0 +1,5 @@
+import { Scheduler } from './rxjs/scheduler';
+
+export function animate(marbles: string): void {
+  Scheduler.animate(marbles);
+}

--- a/src/marble-test.ts
+++ b/src/marble-test.ts
@@ -3,10 +3,14 @@ import { Scheduler } from './rxjs/scheduler';
 
 export function marbleTest(fn: () => void): () => void {
   return () => {
-    Scheduler.get().run((helpers: RunHelpers) => {
-      Scheduler.captureAnimate(helpers.animate);
-      fn();
-      Scheduler.installNegationAwareAssert();
-    });
+    try {
+      Scheduler.get().run((helpers: RunHelpers) => {
+        Scheduler.captureAnimate(helpers.animate);
+        fn();
+        Scheduler.installNegationAwareAssert();
+      });
+    } finally {
+      Scheduler.clearFlushTests();
+    }
   };
 }

--- a/src/marble-test.ts
+++ b/src/marble-test.ts
@@ -1,0 +1,12 @@
+import { RunHelpers } from 'rxjs/internal/testing/TestScheduler';
+import { Scheduler } from './rxjs/scheduler';
+
+export function marbleTest(fn: () => void): () => void {
+  return () => {
+    Scheduler.get().run((helpers: RunHelpers) => {
+      Scheduler.captureAnimate(helpers.animate);
+      fn();
+      Scheduler.installNegationAwareAssert();
+    });
+  };
+}

--- a/src/marblizer.ts
+++ b/src/marblizer.ts
@@ -3,7 +3,7 @@ import { MarblesGlossary } from './marbles-glossary';
 import { NotificationEvent } from './notification-event';
 import { NotificationKindChars, ValueLiteral } from './notification-kind';
 
-const frameStep = 10;
+const frameStep = 1;
 
 export class Marblizer {
   public static marblize(messages: TestMessages): string {

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -65,6 +65,10 @@ export class Scheduler {
     Scheduler.onFlush.push(fn);
   }
 
+  public static clearFlushTests(): void {
+    Scheduler.flushTests().length = 0;
+  }
+
   public static installNegationAwareAssert(): void {
     const scheduler = Scheduler.get();
     const flushTests = Scheduler.flushTests();

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -40,6 +40,10 @@ export class Scheduler {
     return (Scheduler.get() as any)['flushTests'];
   }
 
+  public static captureAnimate(animate: (marbles: string) => void): void {
+    Scheduler.currentAnimate = animate;
+  }
+
   public static markLastNegated(): void {
     const tests = Scheduler.flushTests();
     tests[tests.length - 1][NEGATED] = true;

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -11,11 +11,17 @@ export class Scheduler {
 
   private static onFlush: (() => void)[] = [];
   private static currentAnimate: ((marbles: string) => void) | null = null;
+  private static prevFrameTimeFactor = 0;
 
   public static init(): void {
-    Scheduler.instance = new TestScheduler(assertDeepEqual);
+    const scheduler = new TestScheduler(assertDeepEqual);
+    (scheduler as any).runMode = true;
+    scheduler.maxFrames = Infinity;
+    Scheduler.instance = scheduler;
     Scheduler.onFlush = [];
     Scheduler.currentAnimate = null;
+    Scheduler.prevFrameTimeFactor = TestScheduler.frameTimeFactor;
+    TestScheduler.frameTimeFactor = 1;
   }
 
   public static get(): TestScheduler {
@@ -85,11 +91,12 @@ export class Scheduler {
     const scheduler = Scheduler.get();
     Scheduler.installNegationAwareAssert();
     scheduler.run(() => {
-      TestScheduler.frameTimeFactor = 10;
+      /* run() forces frameTimeFactor = 1 internally; no override needed */
     });
     while (Scheduler.onFlush.length > 0) {
       Scheduler.onFlush.shift()?.();
     }
+    TestScheduler.frameTimeFactor = Scheduler.prevFrameTimeFactor;
     Scheduler.reset();
   }
 

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -4,11 +4,18 @@ import { TestScheduler } from 'rxjs/testing';
 
 import { assertDeepEqual } from './assert-deep-equal';
 
+const NEGATED = Symbol('jest-marbles-negated');
+
 export class Scheduler {
   public static instance: TestScheduler | null;
 
+  private static onFlush: (() => void)[] = [];
+  private static currentAnimate: ((marbles: string) => void) | null = null;
+
   public static init(): void {
     Scheduler.instance = new TestScheduler(assertDeepEqual);
+    Scheduler.onFlush = [];
+    Scheduler.currentAnimate = null;
   }
 
   public static get(): TestScheduler {
@@ -20,6 +27,70 @@ export class Scheduler {
 
   public static reset(): void {
     Scheduler.instance = null;
+    Scheduler.currentAnimate = null;
+  }
+
+  private static flushTests(): any[] {
+    return (Scheduler.get() as any)['flushTests'];
+  }
+
+  public static markLastNegated(): void {
+    const tests = Scheduler.flushTests();
+    tests[tests.length - 1][NEGATED] = true;
+  }
+
+  public static markLastReady(): void {
+    const tests = Scheduler.flushTests();
+    tests[tests.length - 1].ready = true;
+  }
+
+  public static queueOnFlush(fn: () => void): void {
+    Scheduler.onFlush.push(fn);
+  }
+
+  private static installNegationAwareAssert(): void {
+    const scheduler = Scheduler.get();
+    const flushTests = Scheduler.flushTests();
+    const hasNegated = flushTests.some((t) => t[NEGATED]);
+    if (!hasNegated) {
+      return;
+    }
+    const negatedSet = new WeakSet<object>(flushTests.filter((t) => t[NEGATED]));
+    const readyTests = flushTests.filter((t) => t.ready);
+    let callIndex = 0;
+
+    (scheduler as any).assertDeepEqual = (actual: any, expected: any) => {
+      const test = readyTests[callIndex++];
+      if (test && negatedSet.has(test)) {
+        let threw = false;
+        try {
+          assertDeepEqual(actual, expected);
+        } catch {
+          threw = true;
+        }
+        if (!threw) {
+          throw new Error(
+            'Expected observables to differ, but they matched.\n' +
+              `  Received: ${JSON.stringify(actual)}\n` +
+              `  Not expected: ${JSON.stringify(expected)}`
+          );
+        }
+      } else {
+        assertDeepEqual(actual, expected);
+      }
+    };
+  }
+
+  public static teardown(): void {
+    const scheduler = Scheduler.get();
+    Scheduler.installNegationAwareAssert();
+    scheduler.run(() => {
+      TestScheduler.frameTimeFactor = 10;
+    });
+    while (Scheduler.onFlush.length > 0) {
+      Scheduler.onFlush.shift()?.();
+    }
+    Scheduler.reset();
   }
 
   public static materializeInnerObservable(observable: Observable<any>, outerFrame: number): TestMessages {

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -44,6 +44,13 @@ export class Scheduler {
     Scheduler.currentAnimate = animate;
   }
 
+  public static animate(marbles: string): void {
+    if (!Scheduler.currentAnimate) {
+      throw new Error('animate() can only be used inside marbleTest()');
+    }
+    Scheduler.currentAnimate(marbles);
+  }
+
   public static markLastNegated(): void {
     const tests = Scheduler.flushTests();
     tests[tests.length - 1][NEGATED] = true;

--- a/src/rxjs/scheduler.ts
+++ b/src/rxjs/scheduler.ts
@@ -54,7 +54,7 @@ export class Scheduler {
     Scheduler.onFlush.push(fn);
   }
 
-  private static installNegationAwareAssert(): void {
+  public static installNegationAwareAssert(): void {
     const scheduler = Scheduler.get();
     const flushTests = Scheduler.flushTests();
     const hasNegated = flushTests.some((t) => t[NEGATED]);


### PR DESCRIPTION
## What

Switches jest-marbles to drive rxjs's `TestScheduler` in **run mode**, unblocking time-progression syntax (`5000ms b`) and real-time marble tests. Closes #117.

## Two paths, one timing model

- **Eager API retrofitted** — `cold`/`hot`/`time`/`schedule` + `expect().toBeObservable()` are unchanged in shape but now run-mode timed: **1ms per frame** (was 10) and `Nms`/`Ns`/`Nm` syntax parses. The per-test lifecycle is encapsulated on the `Scheduler` wrapper (composition over `TestScheduler`, no subclassing).
- **New `marbleTest(fn)`** — used as `it('name', marbleTest(() => { ... }))`. Runs a jest-marbles-style body inside a real `scheduler.run()`, enabling `animate()` and virtualized `setTimeout`/`Date.now` for the code under test. Wraps only the callback, so `it.only`/`.skip`/`.each` compose for free.
- **New `animate(marbles)`** global — valid only inside `marbleTest`, throws otherwise.

## BREAKING CHANGES (→ 4.0.0)

- Marble frames are **1ms each** (was 10). `time('--|')` returns `2`, not `20`. Re-baseline any hard-coded frame numbers.
- Marble **diagrams are unchanged** — `cold('--a--b|')` vs `cold('--a--b|')` still passes.
- `TestScheduler.frameTimeFactor` is **no longer honored** — use `Nms` syntax for durations.
- Time operators use real virtual time: `cold('a 250ms b|').pipe(debounceTime(250))` ⇒ `'250ms a 1ms (b|)'`.

See the README "v4 migration (run mode)" section.

## Tests

Full `yarn ci` green: eslint, 72 unit (+1 skipped), tsup CJS+ESM+DTS build, e2e (node + jsdom). New specs cover: `time()` value, `Nms` parsing, debounceTime/delay, `animate()` elapsed frames, fake-async `delay()` virtualization, and `.not` negation parity inside `marbleTest`.

## Notes

- A negated assertion that fails inside `marbleTest` previously double-threw (once in `run()`, once in `afterEach`); fixed by clearing residual flushTests in a `finally`.
- Follow-ups (non-blocking, from review): optional dev-warning when a not-`ready` expectation is dropped; explicit single-throw negation test; a direct fake-`setTimeout`/`Date.now` test for the SUT.